### PR TITLE
Fix can't create same secret in multiple namespaces

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -33,9 +33,10 @@ local opaqueSecrets() = [
 ];
 
 local namespaced(secrets) = {
-  [namespacedName(name).name]: secrets[name] {
+  ['%(namespace)s_%(name)s' % namespacedName(name)]: secrets[name] {
     metadata+: {
       namespace: namespacedName(name).namespace,
+      name: namespacedName(name).name,
     },
   }
   for name in std.objectFields(secrets)

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -20,6 +20,17 @@ parameters:
             -----BEGIN PRIVATE KEY-----
             MIIHGFEDCBA....
             -----END PRIVATE KEY-----
+      namespaceB/tlsA:
+        type: 'kubernetes.io/tls'
+        stringData:
+          'tls.crt': |
+            -----BEGIN CERTIFICATE-----
+            MIIABCDEFGH.....
+            -----END CERTIFICATE-----
+          'tls.key': |
+            -----BEGIN PRIVATE KEY-----
+            MIIHGFEDCBA....
+            -----END PRIVATE KEY-----
       tlsB:
         type: 'kubernetes.io/tls'
         stringData:

--- a/tests/golden/defaults/secrets/secrets/10_secrets.yaml
+++ b/tests/golden/defaults/secrets/secrets/10_secrets.yaml
@@ -2,17 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    name: dockercfgA
-  name: dockercfgA
-  namespace: namespaceA
-stringData:
-  dockercfg: ewogICJhdXRocyI6IHsKICAgICJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOiB7CiAgICAgICJhdXRoIjogImFzbGRrZmphbGtnamFsc2tqZmFzbGtkZmoiCiAgICB9CiAgfQp9Cg==
-type: kubernetes.io/dockercfg
----
-apiVersion: v1
-kind: Secret
-metadata:
-  labels:
     name: dockercfgB
   name: dockercfgB
   namespace: default
@@ -24,12 +13,41 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    name: geheimB
-  name: geheimB
-  namespace: othernsB
+    name: tlsB
+  name: tlsB
+  namespace: default
 stringData:
-  keyC: valueC
+  tls.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIUVWXYZ.....
+    -----END CERTIFICATE-----
+  tls.key: |
+    -----BEGIN PRIVATE KEY-----
+    MIIZYXWVU....
+    -----END PRIVATE KEY-----
+type: kubernetes.io/tls
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    name: wouldYou
+  name: wouldYou
+  namespace: default
+stringData:
+  likeToC: valueC
 type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    name: dockercfgA
+  name: dockercfgA
+  namespace: namespaceA
+stringData:
+  dockercfg: ewogICJhdXRocyI6IHsKICAgICJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOiB7CiAgICAgICJhdXRoIjogImFzbGRrZmphbGtnamFsc2tqZmFzbGtkZmoiCiAgICB9CiAgfQp9Cg==
+type: kubernetes.io/dockercfg
 ---
 apiVersion: v1
 kind: Secret
@@ -65,17 +83,17 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    name: tlsB
-  name: tlsB
-  namespace: default
+    name: tlsA
+  name: tlsA
+  namespace: namespaceB
 stringData:
   tls.crt: |
     -----BEGIN CERTIFICATE-----
-    MIIUVWXYZ.....
+    MIIABCDEFGH.....
     -----END CERTIFICATE-----
   tls.key: |
     -----BEGIN PRIVATE KEY-----
-    MIIZYXWVU....
+    MIIHGFEDCBA....
     -----END PRIVATE KEY-----
 type: kubernetes.io/tls
 ---
@@ -83,9 +101,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    name: wouldYou
-  name: wouldYou
-  namespace: default
+    name: geheimB
+  name: geheimB
+  namespace: othernsB
 stringData:
-  likeToC: valueC
+  keyC: valueC
 type: Opaque


### PR DESCRIPTION
If the secretname is the same in different namespaces, the component failes to render the yaml file.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
